### PR TITLE
Hill shading improvements + new algorithm

### DIFF
--- a/mapsforge-map-android/src/main/java/org/mapsforge/map/android/hills/DemFileAndroidContent.java
+++ b/mapsforge-map-android/src/main/java/org/mapsforge/map/android/hills/DemFileAndroidContent.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2022 usrusr
+ * Copyright 2024 Sublimis
  *
  * This program is free software: you can redistribute it and/or modify it under the
  * terms of the GNU Lesser General Public License as published by the Free Software
@@ -15,6 +16,7 @@
 package org.mapsforge.map.android.hills;
 
 import android.content.ContentResolver;
+
 import org.mapsforge.core.util.IOUtils;
 import org.mapsforge.map.layer.hills.DemFile;
 import org.mapsforge.map.layer.hills.DemFileFS;
@@ -22,11 +24,10 @@ import org.mapsforge.map.layer.hills.DemFileFS;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.ByteBuffer;
 
 public class DemFileAndroidContent implements DemFile {
-    private final DemFolderAndroidContent.Entry entry;
-    private final ContentResolver contentResolver;
+    protected final DemFolderAndroidContent.Entry entry;
+    protected final ContentResolver contentResolver;
 
     public DemFileAndroidContent(DemFolderAndroidContent.Entry entry, ContentResolver contentResolver) {
         this.entry = entry;
@@ -49,7 +50,7 @@ public class DemFileAndroidContent implements DemFile {
     }
 
     @Override
-    public ByteBuffer asByteBuffer() throws IOException {
+    public InputStream asStream() throws IOException {
         InputStream stream = null;
         try {
             String nameLowerCase = entry.name.toLowerCase();
@@ -57,7 +58,7 @@ public class DemFileAndroidContent implements DemFile {
             if (nameLowerCase.endsWith(".zip")) {
                 return DemFileFS.tryZippedSingleHgt(entry.name, stream);
             } else {
-                return DemFileFS.streamAsByteBuffer(entry.name, stream, (int) entry.size);
+                return DemFileFS.streamReadPart(entry.name, stream, (int) entry.size);
             }
         } finally {
             IOUtils.closeQuietly(stream);

--- a/mapsforge-map-android/src/main/java/org/mapsforge/map/android/hills/DemFolderAndroidContent.java
+++ b/mapsforge-map-android/src/main/java/org/mapsforge/map/android/hills/DemFolderAndroidContent.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2022 usrusr
+ * Copyright 2024 Sublimis
  *
  * This program is free software: you can redistribute it and/or modify it under the
  * terms of the GNU Lesser General Public License as published by the Free Software
@@ -19,6 +20,7 @@ import android.content.Context;
 import android.database.Cursor;
 import android.net.Uri;
 import android.provider.DocumentsContract;
+
 import org.mapsforge.core.util.IOUtils;
 import org.mapsforge.map.layer.hills.DemFile;
 import org.mapsforge.map.layer.hills.DemFolder;
@@ -134,7 +136,7 @@ public class DemFolderAndroidContent implements DemFolder {
         }
     }
 
-    static class Entry {
+    public static class Entry {
         final Uri uri;
         final String name;
         final boolean isDir;
@@ -178,11 +180,11 @@ public class DemFolderAndroidContent implements DemFolder {
         };
 
         Cursor c = null;
+        List<Entry> result = new ArrayList<>();
         try {
             c = contentResolver.query(childrenUri, columns, null, null, null);
 
-            List<Entry> result = new ArrayList<>();
-            while (c.moveToNext()) {
+            while (c != null && c.moveToNext()) {
                 String fileDocId = c.getString(0);
                 String name = c.getString(1);
                 String mimeType = c.getString(2);

--- a/mapsforge-map/src/main/java/org/mapsforge/map/layer/hills/ClearAsymmetryShadingAlgorithm.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/layer/hills/ClearAsymmetryShadingAlgorithm.java
@@ -1,0 +1,275 @@
+/*
+ * Copyright 2017 usrusr
+ * Copyright 2024 Sublimis
+ *
+ * This program is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.mapsforge.map.layer.hills;
+
+import org.mapsforge.core.util.MercatorProjection;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Flat surfaces, or all surfaces with slope less than minSlope, will have no shade (they look the same as without hill shading);
+ * It is the main distinguishing feature of this algorithm.
+ * Slopes are shaded non-linearly using sqrt mapping by default, so gentle slopes will have more pronounced differences between them.
+ * Linear and square mappings are also available.
+ * There is a special factor, less than 1, that determines in a simple way how much less shading the northwest slopes get,
+ * as the idea is that NW slopes should be somewhat lighter than SE slopes.
+ */
+public class ClearAsymmetryShadingAlgorithm extends AbsShadingAlgorithmDefaults {
+
+    /** Linear mapping from slope value to shade value. */
+    public static final int MODE_LINEAR = 1;
+    /** Steep slopes will have more pronounced differences between them. */
+    public static final int MODE_SQUARE = 2;
+    /** (Default) Gentle slopes will have more pronounced differences between them. */
+    public static final int MODE_SQROOT = 3;
+    public static final int MODE_DEFAULT = MODE_SQROOT;
+
+    public static final double MAX_SLOPE_DEFAULT = 60;
+    public static final double MIN_SLOPE_DEFAULT = 0;
+    public static final double NW_FACTOR_DEFAULT = 0.6;
+
+    public static final int SHADE_MIN = 0, SHADE_MAX = 255;
+
+    protected final double mMinSlope, mMaxSlope, mNorthWestFactor;
+    protected final int mMode;
+
+    /**
+     * @param maxSlope        The smallest slope that will have the darkest shade.
+     *                        All larger slopes will have the same shade, the darkest one.
+     *                        [percentage, %]
+     * @param minSlope        The largest slope that will have the lightest shade.
+     *                        All smaller slopes will have the same shade, the lightest one.
+     *                        Should be in the range [0..maxSlope>.
+     *                        The default is 0 (zero).
+     *                        [percentage, %]
+     * @param northWestFactor Number in the range [0..1], as the idea is that NW slopes should be somewhat lighter than SE slopes.
+     * @param mode            Should be one of the following:
+     *                        MODE_SQRT (Default; Gentle slopes will have more pronounced differences between them),
+     *                        MODE_SQUARE (Steep slopes will have more pronounced differences between them),
+     *                        MODE_LINEAR (Linear mapping from slope value to shade value).
+     */
+    public ClearAsymmetryShadingAlgorithm(double maxSlope, double minSlope, double northWestFactor, int mode) {
+        mMaxSlope = maxSlope;
+        mMinSlope = minSlope;
+        mNorthWestFactor = boundToLimits(0, northWestFactor, 1);
+        mMode = mode;
+    }
+
+    /**
+     * @param maxSlope        The smallest slope that will have the darkest shade.
+     *                        All larger slopes will have the same shade, the darkest one.
+     *                        [percentage, %]
+     * @param northWestFactor Number in the range [0..1], as the idea is that NW slopes should be somewhat lighter than SE slopes.
+     * @param mode            Should be one of the following:
+     *                        MODE_SQRT (Default; Gentle slopes will have more pronounced differences between them),
+     *                        MODE_SQUARE (Steep slopes will have more pronounced differences between them),
+     *                        MODE_LINEAR (Linear mapping from slope value to shade value).
+     */
+    public ClearAsymmetryShadingAlgorithm(double maxSlope, double northWestFactor, int mode) {
+        this(maxSlope, MIN_SLOPE_DEFAULT, northWestFactor, mode);
+    }
+
+    /**
+     * Uses default minSlope = 0, and default mode (sqrt).
+     *
+     * @param maxSlope        The smallest slope that will have the darkest shade.
+     *                        All larger slopes will have the same shade, the darkest one.
+     *                        [percentage, %]
+     * @param northWestFactor Number in the range [0..1], as the idea is that NW slopes should be somewhat lighter than SE slopes.
+     */
+    public ClearAsymmetryShadingAlgorithm(double maxSlope, double northWestFactor) {
+        this(maxSlope, northWestFactor, MODE_DEFAULT);
+    }
+
+    /**
+     * Uses default minSlope = 0, default northWestFactor = 0.6, and default mode (sqrt).
+     *
+     * @param maxSlope The smallest slope that will have the darkest shade.
+     *                 All larger slopes will have the same shade, the darkest one.
+     *                 [percentage, %]
+     */
+    public ClearAsymmetryShadingAlgorithm(double maxSlope) {
+        this(maxSlope, NW_FACTOR_DEFAULT);
+    }
+
+    /**
+     * Uses default maxSlope = 60, default minSlope = 0, default northWestFactor = 0.6, and default mode (sqrt).
+     */
+    public ClearAsymmetryShadingAlgorithm() {
+        this(MAX_SLOPE_DEFAULT);
+    }
+
+    /**
+     * Should return values from SHADE_MIN to SHADE_MAX (0 to 255) using whatever range required (within reason).
+     *
+     * @param slope [percentage, %]
+     */
+    protected byte getShade(final double slope) {
+        double map = mapping(slope);
+
+        if (slope < 0) {
+            map = mNorthWestFactor * map;
+        }
+
+        return (byte) Math.round(map);
+    }
+
+    protected double mapping(final double slope) {
+        double retVal = 0;
+
+        switch (mMode)
+        {
+            case MODE_SQROOT:
+            default:
+                retVal = sqrtMapping(SHADE_MIN, SHADE_MAX, Math.abs(slope), mMinSlope, mMaxSlope);
+                break;
+
+            case MODE_LINEAR:
+                retVal = linearMapping(SHADE_MIN, SHADE_MAX, Math.abs(slope), mMinSlope, mMaxSlope);
+                break;
+
+            case MODE_SQUARE:
+                retVal = squareMapping(SHADE_MIN, SHADE_MAX, Math.abs(slope), mMinSlope, mMaxSlope);
+                break;
+        }
+
+        return retVal;
+    }
+
+    public static double boundToLimits(final double min, final double value, final double max) {
+        return Math.max(min, Math.min(value, max));
+    }
+
+    public static double safeSqrt(final double value) {
+        return Math.sqrt(Math.max(0, value));
+    }
+
+    public static double square(final double value) {
+        return value * value;
+    }
+
+    /**
+     * Faster in the beginning, slower in the end.
+     * To get a decreasing mapping, startLimit can be larger than the endLimit.
+     */
+    public static double sqrtMapping(double startLimit, double endLimit, double param, double paramLowLimit, double paramHighLimit) {
+        double retVal = startLimit;
+
+        if (paramLowLimit != paramHighLimit) {
+            retVal = startLimit + boundToLimits(0, safeSqrt(Math.max(0, param - paramLowLimit) / (paramHighLimit - paramLowLimit)), 1) * (endLimit - startLimit);
+        }
+
+        return retVal;
+    }
+
+    /**
+     * Slower in the beginning, faster in the end.
+     * To get a decreasing mapping, startLimit can be larger than the endLimit.
+     */
+    public static double squareMapping(double startLimit, double endLimit, double param, double paramLowLimit, double paramHighLimit) {
+        double retVal = startLimit;
+
+        if (paramLowLimit != paramHighLimit) {
+            retVal = startLimit + boundToLimits(0, square(Math.max(0, param - paramLowLimit) / (paramHighLimit - paramLowLimit)), 1) * (endLimit - startLimit);
+        }
+
+        return retVal;
+    }
+
+    /**
+     * Linear, constant slope.
+     * To get a decreasing mapping, start can be larger than the end.
+     */
+    public static double linearMapping(double start, double end, double param, double paramLow, double paramHigh) {
+        double retVal = start;
+
+        if (paramLow != paramHigh) {
+            retVal = start + boundToLimits(0, (param - paramLow) / (paramHigh - paramLow), 1) * (end - start);
+        }
+
+        return retVal;
+    }
+
+    @Override
+    protected byte[] convert(InputStream din, int axisLength, int rowLen, int padding, HgtCache.HgtFileInfo fileInfo) throws IOException {
+        final byte[] bytes = new byte[(axisLength + 2 * padding) * (axisLength + 2 * padding)];
+        final short[] ringbuffer = new short[rowLen];
+
+        int outidx = (axisLength + 2 * padding) * padding + padding;
+        int rbcur = 0;
+        {
+            short last = 0;
+            for (int col = 0; col < rowLen; col++) {
+                last = readNext(din, last);
+                ringbuffer[rbcur++] = last;
+            }
+        }
+
+        double southPerPixel = MercatorProjection.calculateGroundResolution(fileInfo.southLat(), axisLength * 170L);
+        double northPerPixel = MercatorProjection.calculateGroundResolution(fileInfo.northLat(), axisLength * 170L);
+
+        double southPerPixelByLine = southPerPixel / (2 * axisLength);
+        double northPerPixelByLine = northPerPixel / (2 * axisLength);
+
+        for (int line = 1; line <= axisLength; line++) {
+            if (rbcur >= rowLen) {
+                rbcur = 0;
+            }
+
+            short nw = ringbuffer[rbcur];
+            short sw = readNext(din, nw);
+            ringbuffer[rbcur++] = sw;
+
+            double metersPerPixelDiagonal = Math.sqrt(2) * (southPerPixelByLine * line + northPerPixelByLine * (axisLength - line));
+
+            for (int col = 1; col <= axisLength; col++) {
+                short ne = ringbuffer[rbcur];
+                short se = readNext(din, ne);
+                ringbuffer[rbcur++] = se;
+
+                bytes[outidx++] = getShade(100 * (nw - se) / metersPerPixelDiagonal);
+
+                nw = ne;
+            }
+            outidx += 2 * padding;
+        }
+
+        return bytes;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        ClearAsymmetryShadingAlgorithm that = (ClearAsymmetryShadingAlgorithm) o;
+
+        final boolean isMappingSame = Double.compare(mapping(0.5 * (mMaxSlope + mMinSlope)), that.mapping(0.5 * (that.mMaxSlope + that.mMinSlope))) == 0;
+
+        return isMappingSame && Double.compare(mMinSlope, that.mMinSlope) == 0 && Double.compare(mMaxSlope, that.mMaxSlope) == 0 && Double.compare(mNorthWestFactor, that.mNorthWestFactor) == 0 && mMode == that.mMode;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Double.hashCode(mMinSlope);
+        result = 31 * result + Double.hashCode(mMaxSlope);
+        result = 31 * result + Double.hashCode(mNorthWestFactor);
+        result = 31 * result + mMode;
+        result = 31 * result + Double.hashCode(mapping(0.5 * (mMaxSlope + mMinSlope)));
+        return result;
+    }
+}

--- a/mapsforge-map/src/main/java/org/mapsforge/map/layer/hills/DemFile.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/layer/hills/DemFile.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2022 usrusr
+ * Copyright 2024 Sublimis
  *
  * This program is free software: you can redistribute it and/or modify it under the
  * terms of the GNU Lesser General Public License as published by the Free Software
@@ -17,7 +18,6 @@ package org.mapsforge.map.layer.hills;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.ByteBuffer;
 
 public interface DemFile {
     String getName();
@@ -26,5 +26,5 @@ public interface DemFile {
 
     long getSize();
 
-    ByteBuffer asByteBuffer() throws IOException;
+    InputStream asStream() throws IOException;
 }

--- a/mapsforge-map/src/main/java/org/mapsforge/map/layer/hills/HgtCache.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/layer/hills/HgtCache.java
@@ -34,7 +34,7 @@ import java.util.zip.ZipInputStream;
 /**
  * immutably configured, does the work for {@link MemoryCachingHgtReaderTileSource}
  */
-class HgtCache {
+public class HgtCache {
     private static final Logger LOGGER = Logger.getLogger(HgtCache.class.getName());
 
     final DemFolder demFolder;
@@ -292,7 +292,7 @@ class HgtCache {
     }
 
 
-    class HgtFileInfo extends BoundingBox implements ShadingAlgorithm.RawHillTileSource {
+    public class HgtFileInfo extends BoundingBox implements ShadingAlgorithm.RawHillTileSource {
         final DemFile file;
         WeakReference<Future<HillshadingBitmap>> weakRef = null;
 

--- a/mapsforge-map/src/main/java/org/mapsforge/map/layer/hills/SimpleShadingAlgorithm.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/layer/hills/SimpleShadingAlgorithm.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2017 usrusr
+ * Copyright 2024 Sublimis
  *
  * This program is free software: you can redistribute it and/or modify it under the
  * terms of the GNU Lesser General Public License as published by the Free Software
@@ -15,11 +16,11 @@
 package org.mapsforge.map.layer.hills;
 
 import java.io.IOException;
-import java.nio.ByteBuffer;
+import java.io.InputStream;
 import java.util.logging.Logger;
 
 /**
- * Simple, but expressive slope visualisation (e.g. no pretentions of physical accuracy, separate north and west lightsources instead of one northwest, so a round dome would not look round, saturation works different depending on slope direction)
+ * Simple, but expressive slope visualisation (e.g. no pretensions of physical accuracy, separate north and west light sources instead of one northwest, so a round dome would not look round, saturation works different depending on slope direction)
  * <p>
  * <p>variations can be created by overriding {@link #exaggerate(double)}</p>
  */
@@ -28,8 +29,8 @@ public class SimpleShadingAlgorithm extends AbsShadingAlgorithmDefaults {
     public final double linearity;
     public final double scale;
 
-    private byte[] lookup;
-    private int lookupOffset;
+    protected byte[] lookup;
+    protected int lookupOffset;
 
     public SimpleShadingAlgorithm() {
         this(0.1d, 0.666d);
@@ -50,13 +51,6 @@ public class SimpleShadingAlgorithm extends AbsShadingAlgorithmDefaults {
         this.scale = Math.max(0d, scale);
     }
 
-    private static short readNext(ByteBuffer din, short fallback) throws IOException {
-        short read = din.getShort();
-        if (read == Short.MIN_VALUE)
-            return fallback;
-        return read;
-    }
-
     /**
      * should calculate values from -128 to +127 using whatever range required (within reason)
      *
@@ -69,19 +63,7 @@ public class SimpleShadingAlgorithm extends AbsShadingAlgorithmDefaults {
         return ret;
     }
 
-    @Override
-    public int getAxisLenght(HgtCache.HgtFileInfo source) {
-        long size = source.getSize();
-        long elements = size / 2;
-        int rowLen = (int) Math.ceil(Math.sqrt(elements));
-        if (rowLen * rowLen * 2 != size) {
-            return 0;
-        }
-        return rowLen - 1;
-    }
-
-
-    protected byte[] convert(ByteBuffer din, int axisLength, int rowLen, int padding, HgtCache.HgtFileInfo fileInfo) throws IOException {
+    protected byte[] convert(InputStream din, int axisLength, int rowLen, int padding, HgtCache.HgtFileInfo fileInfo) throws IOException {
         byte[] bytes;
 
         short[] ringbuffer = new short[rowLen];
@@ -140,12 +122,12 @@ public class SimpleShadingAlgorithm extends AbsShadingAlgorithmDefaults {
         return bytes;
     }
 
-    private byte exaggerate(byte[] lookup, int x) {
+    protected byte exaggerate(byte[] lookup, int x) {
 
         return lookup[Math.max(0, Math.min(lookup.length - 1, x + lookupOffset))];
     }
 
-    private void fillLookup() {
+    protected void fillLookup() {
         int lowest = 0;
         while (lowest > -1024) {
             double exaggerate = exaggerate(lowest);


### PR DESCRIPTION
- Enable sub-classing of hill shading algorithms, so users of the library can create theirs

- Get rid of the memory mapping of DEM files, use a simple and more efficient `BufferedInputStream` instead (`InputStream `in general, instead of the `ByteBuffer`)

- Create a new hill shading algorithm with better appearance and more customization